### PR TITLE
fix: eip-712 encoding for metaDeposit

### DIFF
--- a/src/StaticATokenLM.sol
+++ b/src/StaticATokenLM.sol
@@ -42,7 +42,11 @@ contract StaticATokenLM is
 
   bytes32 public constant METADEPOSIT_TYPEHASH =
     keccak256(
-      'Deposit(address depositor,address receiver,uint256 assets,uint16 referralCode,bool depositToAave,uint256 nonce,uint256 deadline,PermitParams permit)'
+      'Deposit(address depositor,address receiver,uint256 assets,uint16 referralCode,bool depositToAave,uint256 nonce,uint256 deadline,PermitParams permit)PermitParams(address owner,address spender,uint256 value,uint256 deadline,uint8 v,bytes32 r,bytes32 s)'
+    );
+  bytes32 public constant PERMITPARAMS_TYPEHASH =
+    keccak256(
+      'PermitParams(address owner,address spender,uint256 value,uint256 deadline,uint8 v,bytes32 r,bytes32 s)'
     );
   bytes32 public constant METAWITHDRAWAL_TYPEHASH =
     keccak256(
@@ -145,7 +149,18 @@ contract StaticATokenLM is
               depositToAave,
               nonce,
               deadline,
-              permit
+              keccak256(
+                abi.encode(
+                  PERMITPARAMS_TYPEHASH,
+                  permit.owner,
+                  permi.spender,
+                  permit.value,
+                  permit.deadline,
+                  permit.v,
+                  permit.r,
+                  permit.s
+                )
+              )
             )
           )
         )


### PR DESCRIPTION
Current `METADEPOSIT_TYPEHASH` does not confrom to the EIP-712 standard for nested structs. 

This prevents the user from being able to sign the appropriate message on the frontend. 

See
- https://eips.ethereum.org/EIPS/eip-712
- https://github.com/wevm/viem/discussions/658